### PR TITLE
Deploy Sourcegraph in High-Security Environments

### DIFF
--- a/collateral/deployment/high-security-environments-reference.md
+++ b/collateral/deployment/high-security-environments-reference.md
@@ -1,0 +1,55 @@
+# Deploying Sourcegraph in High Security Environments
+
+## Introduction
+This material is intended to be used as a handout to customers working with a Sourcegraph Customer Engineer to deploy their own instance. The materials are meant to serve as an overview and resource to aid in deep diving into Sourcegraph's documentation and common deployment tasks when deploying in a high security environment.
+
+**Table of Contents:**
+
+- [Introduction](#introduction)
+- [Sourcegraph Setup and Deployment](#sourcegraph-setup-and-deployment)
+	- [Prerequisites](#prerequisites)
+  - [Create your cluster](#create-your-cluster)
+  - [Configure your manifest file](#configure-your-manifest-file)
+  - [Install Sourcegraph](#install-sourcegraph)
+- [Next Steps](#next-steps)
+
+## Sourcegraph Setup and Deployment
+
+### Prerequisites
+- Access to deploy Kubernetes clusters
+  - Minimum Kubernetes version: `v1.19` and `kubectl` `v1.19`
+  - Support for Persistent Volumes (SSDs strongly recommended)
+- Determine resource requirements to properly size your instance: The [Resource Estimator](https://docs.sourcegraph.com/admin/deploy/resource_estimator) can give you a baseline, however work with your Sourcegraph Customer Engineer to ensure you are sized appropriately
+- Install relevant CLIs for your provider of choice:
+  - AWS: [`aws` cli](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) and [`ejsctk`](https://eksctl.io/introduction/#installation)
+  - Azure: [`az` cli](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest)
+  - GCP: [`gcloud` cli](https://cloud.google.com/sdk/gcloud)
+
+### Create your cluster
+- Follow the instructions for your provider of choice to create your Kubernetes (k8s) cluster: [Cloud installation instructions](https://docs.sourcegraph.com/admin/deploy/kubernetes#cloud-installation)
+  - Follow the recommendations for `node type`, `disk type`, and `minimum` and `maximum` nodes
+
+### Configure your manifest file
+Sourcegraph has a list of configurations available and recommended that need to be made to your manifest file to properly install Sourcegraph into your cluster. This includes how to customize the deployment using Kustomize—if you prefer to use Helm, please see the [Helm install instructions](https://docs.sourcegraph.com/admin/deploy/kubernetes/helm), instead. 
+
+Please review the full configuration guide prior to proceeding: [Configure Sourcegraph with Kubernetes](https://docs.sourcegraph.com/admin/deploy/kubernetes/configure). Pay particular attention to configuring a storage class for your cloud provider, configuring network access, and configuring external databases if you choose to use them.
+
+Other sections of the configuration page should be reviewed, but are not required (for example, an external Jaeger instance is optional).
+
+Get started by following these steps to fork the [`deploy-sourcegraph`](https://github.com/sourcegraph/deploy-sourcegraph) repository: [Getting started](https://docs.sourcegraph.com/admin/deploy/kubernetes/configure#getting-started)
+
+- Configurations:
+  - [Storage Class](https://docs.sourcegraph.com/admin/deploy/kubernetes/configure#configure-a-storage-class)
+  - [Network Access](https://docs.sourcegraph.com/admin/deploy/kubernetes/configure#configure-network-access)
+  - [External PostgreSQL Database](https://docs.sourcegraph.com/admin/deploy/kubernetes/configure#sourcegraph-databases)
+  - [Scaling for services](https://docs.sourcegraph.com/admin/deploy/kubernetes/scale#tuning-replica-counts-for-horizontal-scalability)
+  - [Cluster role administrator access](https://kubernetes.io/docs/reference/access-authn-authz/rbac/)
+
+### Install Sourcegraph
+With your manifest file configured, ensure that you can [access your cluster](https://kubernetes.io/docs/tasks/access-application-cluster/access-cluster/) with `kubectl` and `kubectl` is pointed to the proper context.
+
+- Follow the [Direct installation](https://docs.sourcegraph.com/admin/deploy/kubernetes#direct-installation) steps to apply your manifest to your cluster
+- Once your deployment is completed, you can access Sourcegraph via the [ingress](https://docs.sourcegraph.com/admin/deploy/kubernetes/configure#ingress-controller-recommended) you configured in your manifest
+
+## Next steps
+Congratulations, Sourcegraph is now deployed and you can begin to configure your instance. We recommend you review the [Configurating Sourcegraph](https://docs.sourcegraph.com/admin/config) documentation next to [add a code host](https://docs.sourcegraph.com/admin/external_service), [configure authentication and authorization](https://docs.sourcegraph.com/admin/config/authorization_and_authentication), [understand other auth settings](https://docs.sourcegraph.com/admin/auth), [configure your backup strategy](https://docs.sourcegraph.com/admin/deploy/migrate-backup#migration-and-backup-options) and more.


### PR DESCRIPTION
This PR adds a deploy reference for setting up Sourcegraph in high-security environments.

- **Problem Statement**: Currently the Sourcegraph documentation for deploying can have a number of splitting paths making it hard to navigate, and there is limited information on specific requirements when deploying in a high-security environment (such as air gapped deployments)
- **Proposed Solution**: By creating references like this, the CE/CTE team can hand out a reference PDF (converted from this source controlled markdown file) which assists Sourcegraph Admins in navigating through our documentation in order to properly create their clusters and deploy Sourcegraph to them.
  - **Why this?**: This is to serve as a specific use-case reference (deploying in a high-security environment) and is not a replacement for official documentation, but a map to the documentation for this use case. This balances the technical debt involved with maintaining detailed documentation and having two sources of truth with a short, easily digestible map to the source of truth (official documentation). This is also a short, 1 pager, that can be easily sorted through for reference.

Would love your 👀  and a 👍  or 💬  letting me know your thoughts 💭. I'm very open to iterating on these more of course but want to get this deliverable pushed for now and hopefully as doc improvements come, we can iterate from there with minimal maintenance overhead (technical debt).