### PR TITLE
Eliminated deadlinks to learn.sourcegraph.com

### DIFF
--- a/trainings/sourcegraph-101/talk-track.md
+++ b/trainings/sourcegraph-101/talk-track.md
@@ -242,11 +242,6 @@ You can see here now that I can click on `fizz buzz` on the left of the screen, 
 
 With our query filters, you can narrow things down to find just the content you need, based on the results that Sourcegraph is returning!
 
-### Resources
-
-- [Three ways to search code with Sourcegraph](https://learn.sourcegraph.com/three-ways-to-search-code-with-sourcegraph)
-- [Sourcegraph code search cheat sheet](https://learn.sourcegraph.com/how-to-search-code-with-sourcegraph-a-cheat-sheet)
-
 ## Unit 4: Code Monitoring
 
 **Learning goals:** By the end of this unit, users will now how to configure a code monitor.


### PR DESCRIPTION
There were two links to resources on learn.sourcegraph.com which 404ed. I sent a message in the discuss-engineering channel but did not get a response so I figured I would create a pull request removing the links so the appropriate person would see it. Feel free to replace the links I deleted with the same resources hosted elsewhere if they simply changed urls.