### PR TITLE
Add end user training docs for Cody

### DIFF
--- a/trainings/cody/end-user-training.md
+++ b/trainings/cody/end-user-training.md
@@ -140,10 +140,10 @@ Cody's autocomplete is designed to integrate seamlessly into a developer's workf
 Example using Python:
 
 1. Start with a blank `.py` file
-2. Add the following comment `"""Sorting routines"""` as the first line; hit <enter> 
-3. Add the following line `def bubble_sort(items_to_sort):` and hit <enter>
+2. Add the following comment `"""Sorting routines"""` as the first line; hit Enter 
+3. Add the following line `def bubble_sort(items_to_sort):` and hit Enter
 4. Let Cody provide an autocomplete suggestion
-5. To accept the suggestion, hit <tab> and then <enter>
+5. To accept the suggestion, hit Tab and then Enter
 
 ## 4. Commands
 
@@ -173,10 +173,10 @@ When a developer selects a piece of code and invokes the /edit command, Cody ope
 
 Example using Python:
 1. Start with a blank `.py` file
-2. Add the following comment `"""Sorting routines"""` as the first line; hit <enter> 
-3. Add the following line `def bubble_sort(items_to_sort):` and hit <enter>
+2. Add the following comment `"""Sorting routines"""` as the first line; hit Enter 
+3. Add the following line `def bubble_sort(items_to_sort):` and hit Enter
 4. Let Cody provide an autocomplete suggestion
-5. To accept the suggestion, hit <tab> and then <enter>
+5. To accept the suggestion, hit Tab and then Enter
 6. Select the suggested code and invoke the `/edit` command and provide the following prompt `add a console logging statement for each sort operation`
 
 ### Custom commands


### PR DESCRIPTION
Add a baseline talk track for end user Cody training with the following agenda:

Setup (can be done before live training)
Install the IDE extensions
Connect to the Sourcegraph Instance
Adding repo context
Cody chat
General & code specific questions
Provide context using @file and @#symbol
Generate boilerplate
Prompts tips & tricks
Code autocompletions
Commands
Out of the box (/test, /smell, /explain, etc)
Custom commands